### PR TITLE
Update years and use HTTPS for links (where needed) in license headers.

### DIFF
--- a/tawkto.php
+++ b/tawkto.php
@@ -7,13 +7,13 @@
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
+ * https://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to support@tawk.to so we can send you a copy immediately.
  *
  * @copyright   Copyright (c) 2014 Tawk.to
- * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license     https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
 if (!defined('_TB_VERSION_')) {

--- a/views/templates/admin/view.tpl
+++ b/views/templates/admin/view.tpl
@@ -6,13 +6,13 @@
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
+ * https://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to support@tawk.to so we can send you a copy immediately.
  *
  * @copyright   Copyright (c) 2014 Tawk.to
- * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license     https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *
 *}
 <iframe id="tawkIframe" src="" style="min-height: 400px; width : 100%; border: none; margin-top: 20px"></iframe>

--- a/views/templates/hook/widget.tpl
+++ b/views/templates/hook/widget.tpl
@@ -6,13 +6,13 @@
  * This source file is subject to the Open Software License (OSL 3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
+ * https://opensource.org/licenses/osl-3.0.php
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to support@tawk.to so we can send you a copy immediately.
  *
  * @copyright   Copyright (c) 2014 Tawk.to
- * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @license     https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *
 *}
 <!--Start of Tawk.to Script-->


### PR DESCRIPTION
Update years and use HTTPS for links (where needed) in license headers.